### PR TITLE
add sanity blocks: main image, block image, tags

### DIFF
--- a/sanity/schema/embed.ts
+++ b/sanity/schema/embed.ts
@@ -1,11 +1,13 @@
+import { CodeBlockIcon } from '@sanity/icons'
 import { SchemaTypeDefinition } from 'sanity'
 
 import InputEmbedType from '../../sanity/components/InputEmbedType'
 
 const iframe: SchemaTypeDefinition = {
   name: 'embed',
-  title: 'Embedded media',
-  type: 'document',
+  title: 'Embed',
+  type: 'object',
+  icon: CodeBlockIcon,
   fields: [
     {
       name: 'url',

--- a/sanity/schema/post.ts
+++ b/sanity/schema/post.ts
@@ -1,3 +1,4 @@
+import { ImageIcon } from '@sanity/icons'
 import { SchemaTypeDefinition } from 'sanity'
 
 const post: SchemaTypeDefinition = {
@@ -36,8 +37,51 @@ const post: SchemaTypeDefinition = {
       weak: true,
     },
     {
+      title: 'Tags',
+      name: 'tags',
+      type: 'array',
+      of: [{ type: 'string' }],
+      options: {
+        layout: 'tags',
+      },
+    },
+    {
+      title: 'Main Image',
+      name: 'mainImage',
+      type: 'image',
+      fields: [
+        {
+          type: 'string',
+          name: 'alt',
+          title: 'Alternative text',
+          description: `Describe the image to help screen readers`,
+          options: {
+            isHighlighted: true,
+          },
+        },
+      ],
+    },
+    {
       name: 'body',
-      of: [{ type: 'block' }, { type: 'embed' }],
+      of: [
+        { type: 'block' },
+        { type: 'embed' },
+        {
+          type: 'image',
+          icon: ImageIcon,
+          fields: [
+            {
+              type: 'string',
+              name: 'alt',
+              title: 'Alternative text',
+              description: `Describe the image to help screen readers`,
+              options: {
+                isHighlighted: true,
+              },
+            },
+          ],
+        },
+      ],
       title: 'Body',
       type: 'array',
       validation: (Rule) => Rule.required(),


### PR DESCRIPTION
adds Sanity blocks to build out post structure
- main image to render as a thumbnail image on blog post preview
- tags to filter posts by in the menu
- image for the sanity blocks body
- cute icons
- mods embed to object type

Note: only added the blocks and have not added any rendering. I'll be in the woods all week so feel free to add rendering while i'm out. 

