### PR TITLE
Add statically generated top-level routes

### DIFF
--- a/app/(site)/[slug]/page.tsx
+++ b/app/(site)/[slug]/page.tsx
@@ -1,0 +1,21 @@
+import getStaticContent from 'domains/static-content/api/getStaticContent'
+import getStaticContents from 'domains/static-content/api/getStaticContents'
+import StaticContent from 'domains/static-content/components/StaticContent'
+
+export async function generateStaticParams() {
+  const contents = await getStaticContents()
+
+  return contents.map((contents) => ({
+    slug: contents.slug,
+  }))
+}
+
+export default async function SlugPage({ params }) {
+  const { slug } = params as { slug: string | undefined }
+  if (!slug) {
+    throw new Error('No slug found in params')
+  }
+  const content = await getStaticContent(slug)
+
+  return <StaticContent {...content} />
+}

--- a/domains/sanity/schema.ts
+++ b/domains/sanity/schema.ts
@@ -1,8 +1,9 @@
 import embedSchema from 'domains/embed/schema'
 import personSchema from 'domains/person/schema'
 import postSchema from 'domains/post/schema'
+import staticContentSchema from 'domains/static-content/schema'
 import { SchemaTypeDefinition } from 'sanity'
 
 export const schema: { types: SchemaTypeDefinition[] } = {
-  types: [embedSchema, postSchema, personSchema],
+  types: [embedSchema, postSchema, personSchema, staticContentSchema],
 }

--- a/domains/static-content/api/getStaticContent.ts
+++ b/domains/static-content/api/getStaticContent.ts
@@ -12,7 +12,6 @@ async function getStaticContent(slug: string) {
       .grab$(staticContentSelection)
       .slice(0)
   )
-  console.log({ staticContent })
 
   return staticContent
 }

--- a/domains/static-content/api/getStaticContent.ts
+++ b/domains/static-content/api/getStaticContent.ts
@@ -1,0 +1,22 @@
+import 'server-only'
+
+import { runQuery } from 'domains/sanity/utils/client'
+import { q } from 'groqd'
+
+import { staticContentSelection } from '../types'
+
+async function getStaticContent(slug: string) {
+  const staticContent = await runQuery(
+    q('*')
+      .filter(`_type == "staticContent" && slug.current == "${slug}"`)
+      .grab$(staticContentSelection)
+      .slice(0)
+  )
+
+  return staticContent
+}
+
+export type TGetStaticContentResponse = Awaited<
+  ReturnType<typeof getStaticContent>
+>
+export default getStaticContent

--- a/domains/static-content/api/getStaticContent.ts
+++ b/domains/static-content/api/getStaticContent.ts
@@ -12,6 +12,7 @@ async function getStaticContent(slug: string) {
       .grab$(staticContentSelection)
       .slice(0)
   )
+  console.log({ staticContent })
 
   return staticContent
 }

--- a/domains/static-content/api/getStaticContents.ts
+++ b/domains/static-content/api/getStaticContents.ts
@@ -1,0 +1,21 @@
+import 'server-only'
+
+import { runQuery } from 'domains/sanity/utils/client'
+import { q } from 'groqd'
+
+import { staticContentSelection } from '../types'
+
+async function getStaticContents() {
+  const staticContents = await runQuery(
+    q('*', { isArray: true })
+      .filterByType('staticContent')
+      .grab$(staticContentSelection)
+  )
+
+  return staticContents
+}
+
+export type TGetStaticContentsResponse = Awaited<
+  ReturnType<typeof getStaticContents>
+>
+export default getStaticContents

--- a/domains/static-content/components/StaticContent.tsx
+++ b/domains/static-content/components/StaticContent.tsx
@@ -1,0 +1,14 @@
+import { TGetStaticContentResponse } from '../api/getStaticContent'
+
+type TStaticContent = {} & TGetStaticContentResponse
+
+export default function StaticContent({ ...content }: TStaticContent) {
+  return (
+    <div>
+      <h1>{content.title}</h1>
+      {content.body?.map((bio) =>
+        bio.children.map((el) => <span key={el._key}>{el.text}</span>)
+      )}
+    </div>
+  )
+}

--- a/domains/static-content/schema.ts
+++ b/domains/static-content/schema.ts
@@ -30,9 +30,10 @@ const staticContentSchema: SchemaTypeDefinition = {
     },
     {
       name: 'body',
-      of: [{ type: 'block' }],
+      of: [{ type: 'block', validation: (Rule) => Rule.required() }],
       title: 'Body',
       type: 'array',
+      validation: (Rule) => Rule.required(),
     },
   ],
 }

--- a/domains/static-content/schema.ts
+++ b/domains/static-content/schema.ts
@@ -1,0 +1,40 @@
+import { SchemaTypeDefinition } from 'sanity'
+
+const staticContent: SchemaTypeDefinition = {
+  name: 'staticContent',
+  title: 'Static content',
+  type: 'document',
+  fields: [
+    {
+      name: 'title',
+      title: 'Title',
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+    },
+    {
+      name: 'slug',
+      title: 'Slug',
+      type: 'slug',
+      options: {
+        //Change to schema title to automatically populate
+        source: 'title',
+        slugify: (input) =>
+          input
+            .toLowerCase()
+            //Remove spaces
+            .replace(/\s+/g, '-')
+            //Remove special characters
+            .replace(/[&\/\\#,+()$~%.'":*?<>{}]/g, ''),
+        validation: (Rule) => Rule.required(),
+      },
+    },
+    {
+      name: 'body',
+      of: [{ type: 'block' }],
+      title: 'Body',
+      type: 'array',
+    },
+  ],
+}
+
+export default staticContent

--- a/domains/static-content/schema.ts
+++ b/domains/static-content/schema.ts
@@ -1,6 +1,6 @@
 import { SchemaTypeDefinition } from 'sanity'
 
-const staticContent: SchemaTypeDefinition = {
+const staticContentSchema: SchemaTypeDefinition = {
   name: 'staticContent',
   title: 'Static content',
   type: 'document',
@@ -37,4 +37,4 @@ const staticContent: SchemaTypeDefinition = {
   ],
 }
 
-export default staticContent
+export default staticContentSchema

--- a/domains/static-content/types.ts
+++ b/domains/static-content/types.ts
@@ -1,0 +1,9 @@
+import { documentSelection } from 'domains/sanity/types'
+import { q, type Selection } from 'groqd'
+
+export const staticContentSelection = {
+  ...documentSelection,
+  title: q.string(),
+  slug: q.slug('slug'),
+  body: q.contentBlocks(),
+} satisfies Selection


### PR DESCRIPTION
Add a catch-all "static content" type that we use to generate content for static routes like `/about`. We use the `[slug]` param via the app router to statically build the page's html at build time.

Custom handling for routes can be declared using the file router similar to how we handle the `/blog` routes, so we retain flexibility for curated experiences and quick-and-dirty content at a top-level URL.

Ideally, we continue developing the catch-all `[slug]` page as much as possible, enhancing it to meet content needs. But of course custom code is cool and deserves first-class support as well. Best of both worlds.

TODO: handling for when you visit a non-existent route